### PR TITLE
Graph API expects a list of required fields as a comma-separated quer…

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
+++ b/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
@@ -104,7 +104,7 @@ class Inchoo_SocialConnect_Model_Facebook_Info extends Varien_Object
             $response = $this->client->api(
                 '/me',
                 'GET',
-                $this->params
+                array('fields' => implode(',', $this->params))
             );
 
             foreach ($response as $key => $value) {


### PR DESCRIPTION
fixes the way to request the fields on registration with facebook. Fixes the 'could not retreive first_name' error.
